### PR TITLE
Fix warning on incorrect printf type for unsigned int num_bytes

### DIFF
--- a/tests/test_ecc_utils.c
+++ b/tests/test_ecc_utils.c
@@ -114,7 +114,7 @@ void string2scalar(uint32_t * scalar, uint32_t num_word32, char *str) {
 
   if (0 > (padding = 2*num_bytes - strlen(str))) {
     printf(
-        "Error: 2*num_bytes(%d) < strlen(hex) (%zu)\n",
+        "Error: 2*num_bytes(%u) < strlen(hex) (%zu)\n",
         2*num_bytes,
         strlen(str));
     exit(-1);


### PR DESCRIPTION
Minor issued when sanity checking code with cppcheck static analysis:

[tests/test_ecc_utils.c:116]: (warning) %d in format string (no. 1)
  requires 'int' but the argument type is 'unsigned int'.

use %u instead of %d

Signed-off-by: Colin Ian King <colin.king@canonical.com>