### PR TITLE
Bugs

### DIFF
--- a/lib/source/hmac.c
+++ b/lib/source/hmac.c
@@ -96,8 +96,7 @@ int32_t tc_hmac_set_key(TCHmacState_t ctx,
 int32_t tc_hmac_init(TCHmacState_t ctx)
 {
 	/* input sanity check: */
-	if (ctx == (TCHmacState_t) 0 ||
-	    ctx->key == (uint8_t *) 0) {
+	if (ctx == (TCHmacState_t) 0) {
 		return TC_CRYPTO_FAIL;
 	}
 
@@ -114,7 +113,7 @@ int32_t tc_hmac_update(TCHmacState_t ctx,
 		       uint32_t data_length)
 {
 	/* input sanity check: */
-	if (ctx == (TCHmacState_t) 0 || ctx->key == (uint8_t *) 0) {
+	if (ctx == (TCHmacState_t) 0) {
 		return TC_CRYPTO_FAIL;
 	}
 
@@ -128,8 +127,7 @@ int32_t tc_hmac_final(uint8_t *tag, uint32_t taglen, TCHmacState_t ctx)
 	/* input sanity check: */
 	if (tag == (uint8_t *) 0 ||
 	    taglen != TC_SHA256_DIGEST_SIZE ||
-	    ctx == (TCHmacState_t) 0 ||
-	    ctx->key == (uint8_t *) 0) {
+	    ctx == (TCHmacState_t) 0) {
 		return TC_CRYPTO_FAIL;
 	}
 

--- a/lib/source/sha256.c
+++ b/lib/source/sha256.c
@@ -66,7 +66,6 @@ int32_t tc_sha256_update(TCSha256State_t s, const uint8_t *data, size_t datalen)
 {
 	/* input sanity check: */
 	if (s == (TCSha256State_t) 0 ||
-	    s->iv == (uint32_t *) 0 ||
 	    data == (void *) 0) {
 		return TC_CRYPTO_FAIL;
 	} else if (datalen == 0) {
@@ -91,8 +90,7 @@ int32_t tc_sha256_final(uint8_t *digest, TCSha256State_t s)
 
 	/* input sanity check: */
 	if (digest == (uint8_t *) 0 ||
-	    s == (TCSha256State_t) 0 ||
-	    s->iv == (uint32_t *) 0) {
+	    s == (TCSha256State_t) 0) {
 		return TC_CRYPTO_FAIL;
 	}
 


### PR DESCRIPTION
These two patches solve the issue reported by Coverity running on Zephyr/master: array compared to NULL is always false.