### PR TITLE
ecc_dh: Fix discrepancy of ecc_make_key definition and declaration

### DIFF
--- a/lib/include/tinycrypt/ecc_dh.h
+++ b/lib/include/tinycrypt/ecc_dh.h
@@ -83,22 +83,20 @@ extern "C" {
  * @return returns TC_CRYPTO_SUCCESS (1) if the key pair was generated successfully
  *         returns TC_CRYPTO_FAIL (0) if:
  *                the private key is 0
-
+ *
  * @param p_publicKey OUT -- the point representing the public key.
  * @param p_privateKey OUT -- the private key.
  * @param p_random IN -- The random number to use to generate the key pair.
  *
  * @note You must use a new non-predictable random number to generate each
  * new key pair.
- * @note p_random must have NUM_ECC_DIGITS*2 bits of entropy to eliminate
- * bias in keys.
  *
  * @note side-channel countermeasure: algorithm strengthened against timing
  * attack.
  */
 int32_t ecc_make_key(EccPoint *p_publicKey,
 		     uint32_t p_privateKey[NUM_ECC_DIGITS],
-		     uint32_t p_random[NUM_ECC_DIGITS * 2]);
+		     uint32_t p_random[NUM_ECC_DIGITS]);
 
 /**
  * @brief Determine whether or not a given point is on the chosen elliptic curve


### PR DESCRIPTION
ecc_make_key declaration has random size of NUM_ECC_DIGITS * 2 but
definition has (and use) only NUM_ECC_DIGITS.

See: https://gerrit.zephyrproject.org/r/#/c/1982

Change-Id: I696d1ecfca439545ac4a7995500bfb7cb8ed2db5
Signed-off-by: Flavio Santes <flavio.santes@intel.com>