### PR TITLE
Fix bool def

### DIFF
--- a/README
+++ b/README
@@ -51,13 +51,13 @@ Organization:
 
 /lib: C source code of the cryptographic primitives.
 /tests: Test vectors of the cryptographic primitives.
-/doc: Documentation of TinyCrypt. 
+/documentation: Documentation of TinyCrypt. 
 
 ================================================================================
 
 Building:
 
-1) In Makefile.conf set: 
+1) In config.mk set: 
     - CFLAGS for compiler flags.
     - CC for compiler.
 2) In lib/Makefile select the primitives required by your project.

--- a/lib/include/tinycrypt/constants.h
+++ b/lib/include/tinycrypt/constants.h
@@ -39,16 +39,14 @@
 #ifndef __TC_CONSTANTS_H__
 #define __TC_CONSTANTS_H__
 
+#include <stdbool.h>
+ 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 #ifndef NULL
 #define NULL ((void *)0)
-#endif
-
-#ifndef bool
-enum {false, true} bool;
 #endif
 
 #define TC_CRYPTO_SUCCESS 1


### PR DESCRIPTION
This addresses issue #16.

Tinycrypt already requires C99 or later, so inclusion of stdbool.h does not appear to introduce any additional restrictions on usage.