### PR TITLE
Declare MAX_CALLS as const

### DIFF
--- a/lib/source/cmac_mode.c
+++ b/lib/source/cmac_mode.c
@@ -36,7 +36,7 @@
 #include <tinycrypt/utils.h>
 
 /* max number of calls until change the key (2^48).*/
-static uint64_t MAX_CALLS = ((uint64_t)1 << 48);
+const static uint64_t MAX_CALLS = ((uint64_t)1 << 48);
 
 /*
  *  gf_wrap -- In our implementation, GF(2^128) is represented as a 16 byte


### PR DESCRIPTION
MAX_CALLS should be declared as const in order to get it placed to
the .rodata section of the binary.

Signed-off-by: Jarkko Sakkinen <jarkko.sakkinen@linux.intel.com>