### PR TITLE
ecc: Constify constant variables to save RAM

### DIFF
--- a/lib/include/tinycrypt/ecc.h
+++ b/lib/include/tinycrypt/ecc.h
@@ -120,7 +120,7 @@ uint32_t vli_isZero(uint32_t *p_vli);
  * @param p_src IN -- Origin buffer.
  *
  */
-void vli_set(uint32_t *p_dest, uint32_t *p_src);
+void vli_set(uint32_t *p_dest, const uint32_t *p_src);
 
 /*
  * @brief Computes the sign of p_left - p_right.
@@ -133,7 +133,7 @@ void vli_set(uint32_t *p_dest, uint32_t *p_src);
  * @note Side-channel countermeasure: algorithm strengthened against timing
  * attack.
  */
-int32_t vli_cmp(uint32_t *p_left, uint32_t *p_right, int32_t word_size);
+int32_t vli_cmp(const uint32_t *p_left, const uint32_t *p_right, int32_t word_size);
 
 /*
  * @brief Computes p_result = p_left - p_right, returns borrow.
@@ -148,7 +148,7 @@ int32_t vli_cmp(uint32_t *p_left, uint32_t *p_right, int32_t word_size);
  * attack.
  * @note Can modify in place.
  */
-uint32_t vli_sub(uint32_t *p_result, uint32_t *p_left, uint32_t *p_right,
+uint32_t vli_sub(uint32_t *p_result, const uint32_t *p_left, const uint32_t *p_right,
 		uint32_t word_size);
 
 /*
@@ -176,8 +176,8 @@ void vli_cond_set(uint32_t *output, uint32_t *p_true, uint32_t *p_false,
  * @note Side-channel countermeasure: algorithm strengthened against timing
  * attack.
  */
-void vli_modAdd(uint32_t *p_result, uint32_t *p_left, uint32_t *p_right,
-		uint32_t *p_mod);
+void vli_modAdd(uint32_t *p_result, const uint32_t *p_left, const uint32_t *p_right,
+		const uint32_t *p_mod);
 
 /*
  * @brief Computes p_result = (p_left - p_right) % p_mod.
@@ -191,8 +191,8 @@ void vli_modAdd(uint32_t *p_result, uint32_t *p_left, uint32_t *p_right,
  * @note Side-channel countermeasure: algorithm strengthened against timing
  * attack.
  */
-void vli_modSub(uint32_t *p_result, uint32_t *p_left, uint32_t *p_right,
-		uint32_t *p_mod);
+void vli_modSub(uint32_t *p_result, const uint32_t *p_left, const uint32_t *p_right,
+		const uint32_t *p_mod);
 
 /*
  * @brief Computes p_result = (p_left * p_right) % curve_p.
@@ -201,8 +201,8 @@ void vli_modSub(uint32_t *p_result, uint32_t *p_left, uint32_t *p_right,
  * @param p_left IN -- buffer p_left in (p_left * p_right) % curve_p.
  * @param p_right IN -- buffer p_right in (p_left * p_right) % curve_p.
  */
-void vli_modMult_fast(uint32_t *p_result, uint32_t *p_left,
-		uint32_t *p_right);
+void vli_modMult_fast(uint32_t *p_result, const uint32_t *p_left,
+		const uint32_t *p_right);
 
 /*
  * @brief Computes p_result = p_left^2 % curve_p.
@@ -210,7 +210,7 @@ void vli_modMult_fast(uint32_t *p_result, uint32_t *p_left,
  * @param p_result OUT -- result buffer.
  * @param p_left IN -- buffer p_left in (p_left^2 % curve_p).
  */
-void vli_modSquare_fast(uint32_t *p_result, uint32_t *p_left);
+void vli_modSquare_fast(uint32_t *p_result, const uint32_t *p_left);
 
 /*
  * @brief Computes p_result = (p_left * p_right) % p_mod.
@@ -223,8 +223,8 @@ void vli_modSquare_fast(uint32_t *p_result, uint32_t *p_left);
  * @note Side-channel countermeasure: algorithm strengthened against timing
  * attack.
  */
-void vli_modMult(uint32_t *p_result, uint32_t *p_left, uint32_t *p_right,
-		uint32_t *p_mod, uint32_t *p_barrett);
+void vli_modMult(uint32_t *p_result, const uint32_t *p_left, const uint32_t *p_right,
+		const uint32_t *p_mod, uint32_t *p_barrett);
 
 /*
  * @brief Computes modular inversion: (1/p_intput) % p_mod.
@@ -236,8 +236,8 @@ void vli_modMult(uint32_t *p_result, uint32_t *p_left, uint32_t *p_right,
  * @note Side-channel countermeasure: algorithm strengthened against timing
  * attack.
  */
-void vli_modInv(uint32_t *p_result, uint32_t *p_input,
-		uint32_t *p_mod, uint32_t *p_barrett);
+void vli_modInv(uint32_t *p_result, const uint32_t *p_input,
+		const uint32_t *p_mod, const uint32_t *p_barrett);
 
 /*
  * @brief modular reduction based on Barrett's method
@@ -251,8 +251,8 @@ void vli_modInv(uint32_t *p_result, uint32_t *p_input,
 void vli_mmod_barrett(
     uint32_t *p_result,
     uint32_t *p_product,
-    uint32_t *p_mod,
-    uint32_t *p_barrett);
+    const uint32_t *p_mod,
+    const uint32_t *p_barrett);
 
 /*
  * @brief Check if a point is zero.

--- a/lib/source/ecc.c
+++ b/lib/source/ecc.c
@@ -78,12 +78,12 @@
 #define Curve_N_Barrett {0xEEDF9BFE, 0x012FFD85, 0xDF1A6C21, 0x43190552, \
 			0xFFFFFFFF, 0xFFFFFFFE, 0xFFFFFFFF, 0x00000000, 0x00000001}
 
-uint32_t curve_p[NUM_ECC_DIGITS] = Curve_P;
-uint32_t curve_b[NUM_ECC_DIGITS] = Curve_B;
-EccPoint curve_G = Curve_G;
-uint32_t curve_n[NUM_ECC_DIGITS] = Curve_N;
-uint32_t curve_pb[NUM_ECC_DIGITS + 1] = Curve_P_Barrett;
-uint32_t curve_nb[NUM_ECC_DIGITS + 1] = Curve_N_Barrett;
+const uint32_t curve_p[NUM_ECC_DIGITS] = Curve_P;
+const uint32_t curve_b[NUM_ECC_DIGITS] = Curve_B;
+const EccPoint curve_G = Curve_G;
+const uint32_t curve_n[NUM_ECC_DIGITS] = Curve_N;
+const uint32_t curve_pb[NUM_ECC_DIGITS + 1] = Curve_P_Barrett;
+const uint32_t curve_nb[NUM_ECC_DIGITS + 1] = Curve_N_Barrett;
 
 /* ------ Static functions: ------ */
 
@@ -159,8 +159,8 @@ static uint32_t vli_numBits(uint32_t *p_vli)
  *
  * Side-channel countermeasure: algorithm strengthened against timing attack.
  */
-static uint32_t vli_add(uint32_t *p_result, uint32_t *p_left,
-			uint32_t *p_right)
+static uint32_t vli_add(uint32_t *p_result, const uint32_t *p_left,
+			const uint32_t *p_right)
 {
 
 	uint32_t l_carry = 0;
@@ -177,8 +177,8 @@ static uint32_t vli_add(uint32_t *p_result, uint32_t *p_left,
 
 
 /* Computes p_result = p_left * p_right. */
-static void vli_mult(uint32_t *p_result, uint32_t *p_left,
-		     uint32_t *p_right, uint32_t word_size)
+static void vli_mult(uint32_t *p_result, const uint32_t *p_left,
+		     const uint32_t *p_right, uint32_t word_size)
 {
 
 	uint64_t r01 = 0;
@@ -205,7 +205,7 @@ static void vli_mult(uint32_t *p_result, uint32_t *p_left,
 }
 
 /* Computes p_result = p_left^2. */
-static void vli_square(uint32_t *p_result, uint32_t *p_left)
+static void vli_square(uint32_t *p_result, const uint32_t *p_left)
 {
 
 	uint64_t r01 = 0;
@@ -238,7 +238,7 @@ static void vli_square(uint32_t *p_result, uint32_t *p_left)
 
 /* Computes p_result = p_product % curve_p using Barrett reduction. */
 void vli_mmod_barrett(uint32_t *p_result, uint32_t *p_product,
-			     uint32_t *p_mod, uint32_t *p_barrett)
+			     const uint32_t *p_mod, const uint32_t *p_barrett)
 {
 	uint32_t i;
 	uint32_t q1[NUM_ECC_DIGITS + 1];
@@ -286,8 +286,9 @@ void vli_mmod_barrett(uint32_t *p_result, uint32_t *p_product,
  *
  * Side-channel countermeasure: algorithm strengthened against timing attack.
  */
-static void vli_modExp(uint32_t *p_result, uint32_t *p_base,
-		       uint32_t *p_exp, uint32_t *p_mod, uint32_t *p_barrett)
+static void vli_modExp(uint32_t *p_result, const uint32_t *p_base,
+		       const uint32_t *p_exp, const uint32_t *p_mod,
+		       const uint32_t *p_barrett)
 {
 
 	uint32_t acc[NUM_ECC_DIGITS], tmp[NUM_ECC_DIGITS], product[2 * NUM_ECC_DIGITS];
@@ -365,7 +366,7 @@ static void EccPointJacobi_set(EccPointJacobi *target, EccPointJacobi *input)
 
 /* ------ Externally visible functions (see header file for comments): ------ */
 
-void vli_set(uint32_t *p_dest, uint32_t *p_src)
+void vli_set(uint32_t *p_dest, const uint32_t *p_src)
 {
 
 	uint32_t i;
@@ -375,7 +376,7 @@ void vli_set(uint32_t *p_dest, uint32_t *p_src)
 	}
 }
 
-int32_t vli_cmp(uint32_t *p_left, uint32_t *p_right, int32_t word_size)
+int32_t vli_cmp(const uint32_t *p_left, const uint32_t *p_right, int32_t word_size)
 {
 
 	int32_t i, cmp = 0;
@@ -387,8 +388,8 @@ int32_t vli_cmp(uint32_t *p_left, uint32_t *p_right, int32_t word_size)
 	return cmp;
 }
 
-uint32_t vli_sub(uint32_t *p_result, uint32_t *p_left, uint32_t *p_right,
-	uint32_t word_size)
+uint32_t vli_sub(uint32_t *p_result, const uint32_t *p_left,
+		 const uint32_t *p_right, uint32_t word_size)
 {
 
 	uint32_t l_borrow = 0;
@@ -415,8 +416,8 @@ void vli_cond_set(uint32_t *output, uint32_t *p_true, uint32_t *p_false,
 	}
 }
 
-void vli_modAdd(uint32_t *p_result, uint32_t *p_left, uint32_t *p_right,
-	uint32_t *p_mod)
+void vli_modAdd(uint32_t *p_result, const uint32_t *p_left, const uint32_t *p_right,
+	const uint32_t *p_mod)
 {
 	uint32_t l_carry = vli_add(p_result, p_left, p_right);
 	uint32_t p_temp[NUM_ECC_DIGITS];
@@ -425,8 +426,8 @@ void vli_modAdd(uint32_t *p_result, uint32_t *p_left, uint32_t *p_right,
 	vli_cond_set(p_result, p_temp, p_result, l_carry);
 }
 
-void vli_modSub(uint32_t *p_result, uint32_t *p_left, uint32_t *p_right,
-	uint32_t *p_mod)
+void vli_modSub(uint32_t *p_result, const uint32_t *p_left, const uint32_t *p_right,
+	const uint32_t *p_mod)
 {
 	uint32_t l_borrow = vli_sub(p_result, p_left, p_right, NUM_ECC_DIGITS);
 	uint32_t p_temp[NUM_ECC_DIGITS];
@@ -435,8 +436,8 @@ void vli_modSub(uint32_t *p_result, uint32_t *p_left, uint32_t *p_right,
 	vli_cond_set(p_result, p_temp, p_result, l_borrow);
 }
 
-void vli_modMult_fast(uint32_t *p_result, uint32_t *p_left,
-	uint32_t *p_right)
+void vli_modMult_fast(uint32_t *p_result, const uint32_t *p_left,
+	const uint32_t *p_right)
 {
 	uint32_t l_product[2 * NUM_ECC_DIGITS];
 
@@ -444,7 +445,7 @@ void vli_modMult_fast(uint32_t *p_result, uint32_t *p_left,
 	vli_mmod_barrett(p_result, l_product, curve_p, curve_pb);
 }
 
-void vli_modSquare_fast(uint32_t *p_result, uint32_t *p_left)
+void vli_modSquare_fast(uint32_t *p_result, const uint32_t *p_left)
 {
 	uint32_t l_product[2 * NUM_ECC_DIGITS];
 
@@ -452,8 +453,8 @@ void vli_modSquare_fast(uint32_t *p_result, uint32_t *p_left)
 	vli_mmod_barrett(p_result, l_product, curve_p, curve_pb);
 }
 
-void vli_modMult(uint32_t *p_result, uint32_t *p_left, uint32_t *p_right,
-		 uint32_t *p_mod, uint32_t *p_barrett)
+void vli_modMult(uint32_t *p_result, const uint32_t *p_left, const uint32_t *p_right,
+		 const uint32_t *p_mod, uint32_t *p_barrett)
 {
 
 	uint32_t l_product[2 * NUM_ECC_DIGITS];
@@ -462,8 +463,8 @@ void vli_modMult(uint32_t *p_result, uint32_t *p_left, uint32_t *p_right,
 	vli_mmod_barrett(p_result, l_product, p_mod, p_barrett);
 }
 
-void vli_modInv(uint32_t *p_result, uint32_t *p_input, uint32_t *p_mod,
-	uint32_t *p_barrett)
+void vli_modInv(uint32_t *p_result, const uint32_t *p_input, const uint32_t *p_mod,
+	const uint32_t *p_barrett)
 {
 	uint32_t p_power[NUM_ECC_DIGITS];
 


### PR DESCRIPTION
There are several variables in ecc.c that can be const, thereby saving
224 bytes in RAM usage for XIP targets. Making the variables const
also means that several function signatures need to get "const" as
well in order to avoid compiler warnings.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>