### PR TITLE
uECC fixes

### DIFF
--- a/tests/test_ecc_dh.c
+++ b/tests/test_ecc_dh.c
@@ -94,7 +94,7 @@ int ecdh_vectors(char **qx_vec, char **qy_vec, char **d_vec, char **z_vec,
 		uint8_t private_bytes[NUM_ECC_BYTES];
 		uECC_vli_nativeToBytes(private_bytes, NUM_ECC_BYTES, prv);
 		uint8_t z_bytes[NUM_ECC_BYTES];
-		uECC_vli_nativeToBytes(z_bytes, NUM_ECC_BYTES, z);
+		uECC_vli_nativeToBytes(z_bytes, NUM_ECC_BYTES, exp_z);
 
 		rc = uECC_shared_secret(pub_bytes, private_bytes, z_bytes, curve);
 


### PR DESCRIPTION
These were found when executing tests on Qemu emulating a NIOS-II processor.  One is a stack overflow in uECC_shared_secret(), and the other is the use of an uninitialized vector in the test harness.