### PR TITLE
Fix incorrect buffer size

### DIFF
--- a/lib/source/cbc_mode.c
+++ b/lib/source/cbc_mode.c
@@ -91,7 +91,7 @@ int tc_cbc_mode_decrypt(uint8_t *out, unsigned int outlen, const uint8_t *in,
 	    outlen == 0 ||
 	    (inlen % TC_AES_BLOCK_SIZE) != 0 ||
 	    (outlen % TC_AES_BLOCK_SIZE) != 0 ||
-	    outlen != inlen - TC_AES_BLOCK_SIZE) {
+	    outlen != inlen) {
 		return TC_CRYPTO_FAIL;
 	}
 
@@ -101,7 +101,7 @@ int tc_cbc_mode_decrypt(uint8_t *out, unsigned int outlen, const uint8_t *in,
 	 * that would not otherwise be possible.
 	 */
 	p = iv;
-	for (n = m = 0; n < inlen; ++n) {
+	for (n = m = 0; n < outlen; ++n) {
 		if ((n % TC_AES_BLOCK_SIZE) == 0) {
 			(void)tc_aes_decrypt(buffer, in, sched);
 			in += TC_AES_BLOCK_SIZE;

--- a/tests/test_cbc_mode.c
+++ b/tests/test_cbc_mode.c
@@ -132,10 +132,9 @@ int test_1_and_2(void)
 	(void)tc_aes128_set_decrypt_key(&a, key);
 
 	p = &encrypted[TC_AES_BLOCK_SIZE];
-	length = ((unsigned int) sizeof(encrypted)) - TC_AES_BLOCK_SIZE;
+	length = ((unsigned int) sizeof(encrypted));
 
-	if (tc_cbc_mode_decrypt(decrypted, length - TC_AES_BLOCK_SIZE, p, length,
-				encrypted, &a) == 0) {
+	if (tc_cbc_mode_decrypt(decrypted, length, p, length, encrypted, &a) == 0) {
 		TC_ERROR("CBC test #2 (decryption SP 800-38a tests) failed in. "
 			 "%s\n", __func__);
 		result = TC_FAIL;
@@ -161,7 +160,7 @@ int main(void)
 
 	TC_PRINT("Performing CBC tests:\n");
 	result = test_1_and_2();
-	if (result == TC_FAIL) {	
+	if (result == TC_FAIL) {
 		/* terminate test */
 		TC_ERROR("CBC test #1 failed.\n");
 		goto exitTest;


### PR DESCRIPTION
When decrypting with CBC mode, the in and out buffers should be the same size. Even though the IV and ciphertext are contiguous, the in buffer points to the first byte of the ciphertext. The sanity check has been updated accordingly.

Because of this error, the CBC mode tests are reporting the wrong size for the decrypted buffer (80 - 16 - 16 == 48 != 64). This has been corrected.

Also, since the loop in the decryption is writing to the out buffer, the loop conditional has been changed to `n < outlen`.  This should avoid any future errors if `inlen` changes so that it’s no longer equal to `outlen`.