### PR TITLE
g_rng_function should only exist once

### DIFF
--- a/lib/source/ecc.c
+++ b/lib/source/ecc.c
@@ -59,19 +59,19 @@
 /* IMPORTANT: Make sure a cryptographically-secure PRNG is set and the platform
  * has access to enough entropy in order to feed the PRNG regularly. */
 #if default_RNG_defined
-static uECC_RNG_Function g_rng_function = &default_CSPRNG;
+uECC_RNG_Function uECC_rng_function = default_CSPRNG;
 #else
-static uECC_RNG_Function g_rng_function = 0;
+uECC_RNG_Function uECC_rng_function = 0;
 #endif
 
 void uECC_set_rng(uECC_RNG_Function rng_function)
 {
-	g_rng_function = rng_function;
+	uECC_rng_function = rng_function;
 }
 
 uECC_RNG_Function uECC_get_rng(void)
 {
-	return g_rng_function;
+	return uECC_rng_function;
 }
 
 int uECC_curve_private_key_size(uECC_Curve curve)
@@ -841,12 +841,12 @@ int uECC_generate_random_int(uECC_word_t *random, const uECC_word_t *top,
 	uECC_word_t tries;
 	bitcount_t num_bits = uECC_vli_numBits(top, num_words);
 
-	if (!g_rng_function) {
+	if (!uECC_rng_function) {
 		return 0;
 	}
 
 	for (tries = 0; tries < uECC_RNG_MAX_TRIES; ++tries) {
-		if (!g_rng_function((uint8_t *)random, num_words * uECC_WORD_SIZE)) {
+		if (!uECC_rng_function((uint8_t *)random, num_words * uECC_WORD_SIZE)) {
       			return 0;
     		}
 		random[num_words - 1] &=

--- a/lib/source/ecc_dh.c
+++ b/lib/source/ecc_dh.c
@@ -59,11 +59,7 @@
 #include <tinycrypt/ecc_dh.h>
 #include <string.h>
 
-#if default_RNG_defined
-static uECC_RNG_Function g_rng_function = &default_CSPRNG;
-#else
-static uECC_RNG_Function g_rng_function = 0;
-#endif
+extern uECC_RNG_Function uECC_rng_function;
 
 int uECC_make_key_with_d(uint8_t *public_key, uint8_t *private_key,
 			 unsigned int *d, uECC_Curve curve)
@@ -173,7 +169,7 @@ int uECC_shared_secret(const uint8_t *public_key, const uint8_t *private_key,
 
 	/* If an RNG function was specified, try to get a random initial Z value to
 	 * improve protection against side-channel attacks. */
-	if (g_rng_function) {
+	if (uECC_rng_function) {
 		if (!uECC_generate_random_int(p2[carry], curve->p, num_words)) {
 			r = 0;
 			goto clear_and_out;

--- a/lib/source/ecc_dsa.c
+++ b/lib/source/ecc_dsa.c
@@ -57,11 +57,7 @@
 #include <tinycrypt/ecc.h>
 #include <tinycrypt/ecc_dsa.h>
 
-#if default_RNG_defined
-static uECC_RNG_Function g_rng_function = &default_CSPRNG;
-#else
-static uECC_RNG_Function g_rng_function = 0;
-#endif
+extern uECC_RNG_Function uECC_rng_function;
 
 static void bits2int(uECC_word_t *native, const uint8_t *bits,
 		     unsigned bits_size, uECC_Curve curve)
@@ -124,7 +120,7 @@ int uECC_sign_with_k(const uint8_t *private_key, const uint8_t *message_hash,
 
 	/* If an RNG function was specified, get a random number
 	to prevent side channel analysis of k. */
-	if (!g_rng_function) {
+	if (!uECC_rng_function) {
 		uECC_vli_clear(tmp, num_n_words);
 		tmp[0] = 1;
 	}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -18,6 +18,12 @@ TEST_BINARY:=$(TEST_SOURCE:.c=$(DOTEXE))
 # Edit the 'all' content to add/remove tests needed from TinyCrypt library:
 all: $(TEST_BINARY)
 
+.PHONY: run_tests
+run_tests: all
+	for TEST_BIN in $(TEST_BINARY); do \
+		./$$TEST_BIN || exit $$?; \
+	done
+
 clean:
 	-$(RM) $(TEST_BINARY) $(TEST_OBJECTS) $(TEST_DEPS)
 	-$(RM) *~ *.o *.d


### PR DESCRIPTION
ecc.c, ecc_dh.c and ecc_dsa.c declare their own copies of this variable. This PR makes it a single item, shared by all.
Also added a convenience target to tests directory, which'll execute all unit tests.
Try 'make run_tests' there.