### PR TITLE
cmac_mode: s/const static/static const/

### DIFF
--- a/lib/source/cmac_mode.c
+++ b/lib/source/cmac_mode.c
@@ -36,7 +36,7 @@
 #include <tinycrypt/utils.h>
 
 /* max number of calls until change the key (2^48).*/
-const static uint64_t MAX_CALLS = ((uint64_t)1 << 48);
+static const uint64_t MAX_CALLS = ((uint64_t)1 << 48);
 
 /*
  *  gf_wrap -- In our implementation, GF(2^128) is represented as a 16 byte


### PR DESCRIPTION
Just adding tinycrypt as package to [RIOT](https://github.com/RIOT-OS/RIOT). When building with RIOT's default cflags (`-Wextra`), gcc throws a warning about
``` 
`static' is not at beginning of declaration [-Werror=old-style-declaration]`
```

Seems at least the `c99` standard also prefers the `static` declaration to come first:
> (C99, 6.11.5p1) "The placement of a storage-class specifier other than at the beginning of the declaration specifiers in a declaration is an obsolescent feature"

So a simple word-order swap solves this issue...

As I haven't contributed to this project before, is there anything else to do besides opening this PR?
